### PR TITLE
auto release support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.5
+* [Support] Handle versioned commits in addition to SHA commits.
+
 ## 0.0.4
 * [Support] Expand regex to include broader range of urls [#150857294](https://www.pivotaltracker.com/story/show/150857294)
 

--- a/app/Http/Controllers/FrontController.php
+++ b/app/Http/Controllers/FrontController.php
@@ -10,7 +10,7 @@ class FrontController extends Controller {
         $redis = \Illuminate\Support\Facades\Redis::connection();
 
         // was any specific version specified?
-        $key = str_replace(' ', '+', trim(Request::input('key')));
+        $key = Request::input('key');
 
         // try and fetch current application or revision
         $emberApp = env('EMBER_APP');

--- a/app/Http/Controllers/FrontController.php
+++ b/app/Http/Controllers/FrontController.php
@@ -10,7 +10,7 @@ class FrontController extends Controller {
         $redis = \Illuminate\Support\Facades\Redis::connection();
 
         // was any specific version specified?
-        $key = Request::input('key');
+        $key = str_replace(' ', '+', trim(Request::input('key')));
 
         // try and fetch current application or revision
         $emberApp = env('EMBER_APP');

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "b-lab-org/laravel-ember-lightning",
     "description": "A Laravel application to facilitate the Ember Lightning Deploy Strategy",
     "keywords": ["laravel", "ember", "ember-cli-deploy", "redis"],
-    "version": "0.0.4",
+    "version": "0.0.5",
     "license": "MIT",
     "type": "project",
     "require": {

--- a/tests/functional/FrontControllerCest.php
+++ b/tests/functional/FrontControllerCest.php
@@ -41,7 +41,7 @@ class FrontControllerCest
         $versionHtml .= '<body><h1>Welcome to Ember - Revision Commit</h1></body>';
         $versionHtml .= '</html>';
 
-        $this->_versionCommit = "2.0.1%2Be727bae0";
+        $this->_versionCommit = "2.0.1+e727bae0";
         $I->haveInRedis('string', "$this->_appKey:$this->_versionCommit", $versionHtml);
     }
 
@@ -116,7 +116,8 @@ class FrontControllerCest
     public function fetchWithRevisionKey(FunctionalTester $I)
     {
         $I->wantTo('Fetch a known version key of the app');
-        $I->amOnPage("/?key=$this->_appKey:$this->_versionCommit");
+        $version = str_replace('+', '%2B', $this->_versionCommit);
+        $I->amOnPage("/?key=$this->_appKey:$version");
         $I->seeResponseCodeIs(200);
         $I->seeInTitle('Test App');
         $I->seeElement('h1');

--- a/tests/functional/FrontControllerCest.php
+++ b/tests/functional/FrontControllerCest.php
@@ -41,7 +41,7 @@ class FrontControllerCest
         $versionHtml .= '<body><h1>Welcome to Ember - Revision Commit</h1></body>';
         $versionHtml .= '</html>';
 
-        $this->_versionCommit = "2.0.1+e727bae0";
+        $this->_versionCommit = "2.0.1%2Be727bae0";
         $I->haveInRedis('string', "$this->_appKey:$this->_versionCommit", $versionHtml);
     }
 

--- a/tests/functional/FrontControllerCest.php
+++ b/tests/functional/FrontControllerCest.php
@@ -7,6 +7,7 @@ class FrontControllerCest
     private $_appKey;
     private $_currentSha;
     private $_updatedSha;
+    private $_versionCommit;
 
     public function _before(FunctionalTester $I)
     {
@@ -32,6 +33,16 @@ class FrontControllerCest
 
         $this->_updatedSha = 'xyz0000';
         $I->haveInRedis('string', "$this->_appKey:$this->_updatedSha", $shaHtml);
+
+        // the "app:revision+commit" of an ember application
+        $versionHtml = '<!DOCTYPE html>';
+        $versionHtml .= '<html>';
+        $versionHtml .= '<head><title>Test App</title></head>';
+        $versionHtml .= '<body><h1>Welcome to Ember - Revision Commit</h1></body>';
+        $versionHtml .= '</html>';
+
+        $this->_versionCommit = "2.0.1+e727bae0";
+        $I->haveInRedis('string', "$this->_appKey:$this->_versionCommit", $versionHtml);
     }
 
     public function _after(FunctionalTester $I)
@@ -91,7 +102,7 @@ class FrontControllerCest
         $I->assertEquals($h1, 'Welcome to Ember');
     }
 
-	public function fetchUrlEncodedString(FunctionalTester $I)
+    public function fetchUrlEncodedString(FunctionalTester $I)
     {
         $I->wantTo('Fetch the latest version that isn\'t the root');
         $I->amOnPage('/another/url/with%2Bencoded%40strings.net');
@@ -100,5 +111,16 @@ class FrontControllerCest
         $I->seeElement('h1');
         $h1 = $I->grabTextFrom('h1');
         $I->assertEquals($h1, 'Welcome to Ember');
+    }
+
+    public function fetchWithRevisionKey(FunctionalTester $I)
+    {
+        $I->wantTo('Fetch a known version key of the app');
+        $I->amOnPage("/?key=$this->_appKey:$this->_versionCommit");
+        $I->seeResponseCodeIs(200);
+        $I->seeInTitle('Test App');
+        $I->seeElement('h1');
+        $h1 = $I->grabTextFrom('h1');
+        $I->assertEquals($h1, 'Welcome to Ember - Revision Commit');
     }
 }


### PR DESCRIPTION
#### Overview
In preparation of auto releasing Ember applications, this front controller needs to be able to handle deployment keys of SHA and version-commits.

For example:
https://staging.management.bimpactassessment.net/?key=impact-manage:3ba36128eb0997758478ac7e0244d522
https://staging.management.bimpactassessment.net/?key=impact-manage:2.0.1+e727bae0

#### How to test
- Deploy this to one of the staging Ember apps (assuming management app)
- Both above URLs should resolve